### PR TITLE
Enable Dual Compilation for Swift 3.1.1 and 4.1.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,39 @@
-os:
-- osx
-- linux
-language: generic
-sudo: required
-dist: trusty
-osx_image: xcode9
-install:
-  - eval "$(curl -sL https://gist.githubusercontent.com/kylef/5c0475ff02b7c7671d2a/raw/9f442512a46d7a2af7b850d65a7e9bd31edfb09b/swiftenv-install.sh)"
+matrix:
+  include:
+    - name: "Linux Swift 3.1.1"
+      os: linux
+      language: generic
+      dist: trusty
+      sudo: required
+      env:
+        - SWIFT_BRANCH=swift-3.1.1-release
+        - SWIFT_VERSION=swift-3.1.1-RELEASE
+      install:
+        - mkdir swift
+        - curl https://swift.org/builds/$SWIFT_BRANCH/ubuntu1404/$SWIFT_VERSION/$SWIFT_VERSION-ubuntu14.04.tar.gz -s | tar -xz -C swift
+        - export PATH="$(pwd)/swift/$SWIFT_VERSION-ubuntu14.04/usr/bin:$PATH"
+
+    - name: "Linux Swift 4.1.2"
+      os: linux
+      language: generic
+      dist: trusty
+      sudo: required
+      env:
+        - SWIFT_BRANCH=swift-4.1.2-release
+        - SWIFT_VERSION=swift-4.1.2-RELEASE
+      install:
+        - mkdir swift
+        - curl https://swift.org/builds/$SWIFT_BRANCH/ubuntu1404/$SWIFT_VERSION/$SWIFT_VERSION-ubuntu14.04.tar.gz -s | tar -xz -C swift
+        - export PATH="$(pwd)/swift/$SWIFT_VERSION-ubuntu14.04/usr/bin:$PATH"
+
+    - name: "Mac Xcode 9"
+      os: osx
+      osx_image: xcode9.4
+      language: generic
+      sudo: required
+
+
 script:
-- swift build
-- swift test
+  - swift package reset
+  - swift build
+  - swift test

--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,6 @@
 import PackageDescription
 
 let package = Package(
-    name: "Moderator"
+    name: "Moderator",
+    swiftLanguageVersions: [3, 4]
 )

--- a/Sources/Parsers.swift
+++ b/Sources/Parsers.swift
@@ -210,7 +210,7 @@ extension Argument where Value == Bool {
 	/// Counts the number of times an option argument occurs.
 	public func count() -> Argument<Int> {
 		return Argument<Int>(usage: self.usage) { args in
-			let result = try self.map { $0 ? () : nil }.repeat().parse(args)
+			let result = try self.map { $0 ? true : nil }.repeat().parse(args)
 			return (result.value.count, result.remainder)
 		}
 	}

--- a/Sources/SwiftCompat.swift
+++ b/Sources/SwiftCompat.swift
@@ -1,0 +1,22 @@
+#if swift(>=4.0)
+// No Swift 4 back compat mode.
+// This keeps the compiler happy.
+#elseif swift(>=3.0)
+extension String {
+	func dropFirst(_ n: Int = 1) -> String.CharacterView {
+		return self.characters.dropFirst(n)
+	}
+
+	var first: Character? {
+		return self.characters.first
+	}
+
+	var count: Int {
+		return self.characters.count
+	}
+	
+	func split(separator: Character, maxSplits: Int = Int.max, omittingEmptySubsequences: Bool = true) -> [String.CharacterView] {
+		return self.characters.split(separator: separator, maxSplits: maxSplits, omittingEmptySubsequences: omittingEmptySubsequences) 
+	}
+}
+#endif

--- a/Sources/SwiftCompat.swift
+++ b/Sources/SwiftCompat.swift
@@ -1,7 +1,4 @@
-#if swift(>=4.0)
-// No Swift 4 back compat mode.
-// This keeps the compiler happy.
-#elseif swift(>=3.0)
+#if !swift(>=4.0)
 extension String {
 	func dropFirst(_ n: Int = 1) -> String.CharacterView {
 		return self.characters.dropFirst(n)


### PR DESCRIPTION
This enables building for both Swift 3/4 from the same source, and tweaks Travis CI so it builds both to ensure someone doesn’t break one or the other.

* Travis CI config is one I’m using for my projects to check Mac/Linux/Raspberry Pi. It doesn’t use swiftenv, though.
* Uses extensions to “backport” Swift 4 APIs to compile on Swift 3.
* Uses bools instead of empty tuples. Swift 3 gets confused, sadly.