### PR TITLE
Updates to Swift Package Manifest for Swift 4.2 / 5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,14 +13,40 @@ matrix:
         - curl https://swift.org/builds/$SWIFT_BRANCH/ubuntu1404/$SWIFT_VERSION/$SWIFT_VERSION-ubuntu14.04.tar.gz -s | tar -xz -C swift
         - export PATH="$(pwd)/swift/$SWIFT_VERSION-ubuntu14.04/usr/bin:$PATH"
 
-    - name: "Linux Swift 4.1.2"
+    - name: "Linux Swift 4.1.3"
       os: linux
       language: generic
       dist: trusty
       sudo: required
       env:
-        - SWIFT_BRANCH=swift-4.1.2-release
-        - SWIFT_VERSION=swift-4.1.2-RELEASE
+        - SWIFT_BRANCH=swift-4.1.3-release
+        - SWIFT_VERSION=swift-4.1.3-RELEASE
+      install:
+        - mkdir swift
+        - curl https://swift.org/builds/$SWIFT_BRANCH/ubuntu1404/$SWIFT_VERSION/$SWIFT_VERSION-ubuntu14.04.tar.gz -s | tar -xz -C swift
+        - export PATH="$(pwd)/swift/$SWIFT_VERSION-ubuntu14.04/usr/bin:$PATH"
+
+    - name: "Linux Swift 4.2.3"
+      os: linux
+      language: generic
+      dist: trusty
+      sudo: required
+      env:
+        - SWIFT_BRANCH=swift-4.2.3-release
+        - SWIFT_VERSION=swift-4.2.3-RELEASE
+      install:
+        - mkdir swift
+        - curl https://swift.org/builds/$SWIFT_BRANCH/ubuntu1404/$SWIFT_VERSION/$SWIFT_VERSION-ubuntu14.04.tar.gz -s | tar -xz -C swift
+        - export PATH="$(pwd)/swift/$SWIFT_VERSION-ubuntu14.04/usr/bin:$PATH"
+
+    - name: "Linux Swift 5.0"
+      os: linux
+      language: generic
+      dist: trusty
+      sudo: required
+      env:
+        - SWIFT_BRANCH=swift-5.0-release
+        - SWIFT_VERSION=swift-5.0-RELEASE
       install:
         - mkdir swift
         - curl https://swift.org/builds/$SWIFT_BRANCH/ubuntu1404/$SWIFT_VERSION/$SWIFT_VERSION-ubuntu14.04.tar.gz -s | tar -xz -C swift
@@ -32,6 +58,11 @@ matrix:
       language: generic
       sudo: required
 
+    - name: "Mac Xcode 10"
+      os: osx
+      osx_image: xcode10
+      language: generic
+      sudo: required
 
 script:
   - swift package reset

--- a/Package.swift
+++ b/Package.swift
@@ -1,6 +1,8 @@
+// swift-tools-version:3.1
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
 import PackageDescription
 
 let package = Package(
-    name: "Moderator",
-    swiftLanguageVersions: [3, 4]
+    name: "Moderator"
 )

--- a/Package@swift-4.swift
+++ b/Package@swift-4.swift
@@ -1,0 +1,21 @@
+// swift-tools-version:4.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "Moderator",
+    products: [
+        // Products define the executables and libraries produced by a package, and make them visible to other packages.
+        .library(
+            name: "Moderator",
+            targets: ["Moderator"]),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
+        .target(
+            name: "Moderator",
+            path: "Sources")
+    ]
+)

--- a/Package@swift-4.swift
+++ b/Package@swift-4.swift
@@ -16,6 +16,12 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "Moderator",
-            path: "Sources")
+            path: "Sources"),
+
+        // Test Targets
+        .testTarget(
+            name: "ModeratorTests",
+            dependencies: ["Moderator"]
+        )
     ]
 )


### PR DESCRIPTION
Starting with Swift 4.2, the old v3 manifest starts throwing warnings that it is deprecated. Now with Swift 5 out the door, the old v3 manifest no longer builds at all.

This PR does two things:
1) Adds a Package@swift-4.swift manifest using the v4 manifest. This silences the warning and makes it possible to build for Swift 5, while not losing the ability to build for Swift 3. At least until a code change breaks it.
2) Updates the CI configuration to build/test a bunch of Swift compiler versions. On Linux: Swift 3.1.1, Swift 4.1.3, Swift 4.2.3, Swift 5.0. On Mac: Xcode 9.4 and 10. 